### PR TITLE
Fix example section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ CKIP_Client是連接[中央研究院][中央研究院][詞庫小組][詞庫小�
 
 ## 範例 Example
 
-	require 'ckip_client'
+	require 'CKIP_Client'
 	text = File.open('text.txt').read
 	puts CKIP.segment( text )
 


### PR DESCRIPTION
require 的模組名稱跟 lib/ 裡面的不同，改成相同的後就可以跑了
